### PR TITLE
Support packages that are not hosted in repos root

### DIFF
--- a/vanity.go
+++ b/vanity.go
@@ -42,13 +42,24 @@ func Redirect(vcs, importPath, repoRoot string) http.Handler {
 			http.NotFound(w, r)
 			return
 		}
-		vcsroot := ""
+		vcsroot := repoRoot
 		if strings.HasPrefix(r.URL.Path, "/cmd/") {
 			path = r.URL.Path[4:]
-			vcsroot = repoRoot + path
 		} else {
-			vcsroot = repoRoot + r.URL.Path
+			path = r.URL.Path
 		}
+		shortPath := strings.Split(path, "/")
+
+		f := func(c rune) bool {
+			return c == '/'
+		}
+
+		shortPath = strings.FieldsFunc(path, f)
+
+		if (len(shortPath) > 0) {
+			vcsroot = repoRoot + "/" + shortPath[0]
+		}
+
 		if r.FormValue("go-get") != "1" {
 			url := "https://godoc.org/" + r.Host + r.URL.Path
 			http.Redirect(w, r, url, http.StatusTemporaryRedirect)

--- a/vanity_test.go
+++ b/vanity_test.go
@@ -75,6 +75,7 @@ func TestGoTool(t *testing.T) {
 		{"/set?go-get=1", "kkn.fi/set git https://github.com/kare/set"},
 		{"/cmd/vanity?go-get=1", "kkn.fi/cmd/vanity git https://github.com/kare/vanity"},
 		{"/cmd/tcpproxy?go-get=1", "kkn.fi/cmd/tcpproxy git https://github.com/kare/tcpproxy"},
+		{"/pkg/subpkg?go-get=1", "kkn.fi/pkg/subpkg git https://github.com/kare/pkg"},
 	}
 	for _, test := range tests {
 		res := httptest.NewRecorder()


### PR DESCRIPTION
VCSroot should point to a repository, not to the package full path.