### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-created.yaml
+++ b/.github/workflows/release-created.yaml
@@ -1,5 +1,7 @@
 ---
 name: Release created
+permissions:
+  contents: read
 on:
   release:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/kare/vanity/security/code-scanning/2](https://github.com/kare/vanity/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow file `.github/workflows/release-created.yaml`. Since the job is using a reusable workflow, the permissions should be set at the workflow root level to apply to all jobs unless overridden. The minimal starting point is to set `contents: read`, which allows the workflow to read repository contents but not write. If the workflow needs to create or update pull requests, you can add `pull-requests: write`. However, unless you know the workflow needs more, start with the minimal permissions. Add the following block after the `name:` key and before the `on:` key:

```yaml
permissions:
  contents: read
```

This change is sufficient to address the CodeQL warning and follows GitHub's least privilege principle.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
