### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,7 @@
 ---
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/kare/vanity/security/code-scanning/3](https://github.com/kare/vanity/security/code-scanning/3)

To fix the problem, add a `permissions` key to the workflow file `.github/workflows/ci.yaml`. This can be done at the top level (applies to all jobs) or at the job level (applies only to the specific job). Since there is only one job and it is a reusable workflow call, the most straightforward and least intrusive fix is to add a top-level `permissions` block with the minimal required permissions. If you are unsure what permissions are needed, start with `contents: read`, which is the most restrictive and safe default. If the workflow requires more, you can adjust as needed.

**Steps:**
- Insert a `permissions:` block after the `name:` line and before the `on:` block in `.github/workflows/ci.yaml`.
- Set `contents: read` as a minimal starting point.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
